### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A native macOS application to view
 - Alternatively: install via [Homebrew Cask](https://caskroom.github.io/):
 
   ```
-  $ brew cask install jupyter-notebook-viewer
+  $ brew install --cask jupyter-notebook-viewer
   ```
 
 - Quick Look should work out of the box. If it doesn't, check


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524