### PR TITLE
Make notebooks searchable

### DIFF
--- a/Jupyter Notebook Viewer/Base.lproj/Main.storyboard
+++ b/Jupyter Notebook Viewer/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.WebKit2IBPlugin" version="18122"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -174,30 +174,16 @@
                                                 <items>
                                                     <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
                                                         <connections>
-                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                            <action selector="performTextFinderAction:" target="Ady-hI-5gd" id="kpJ-Ov-Zzn"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
-                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
-                                                        <connections>
-                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
-                                                        </connections>
-                                                    </menuItem>
-                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
-                                                        <connections>
-                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
-                                                        </connections>
-                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye"/>
                                                     <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
                                                         <connections>
-                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                            <action selector="performTextFinderAction:" target="Ady-hI-5gd" id="4hO-Rr-bz9"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
-                                                        <connections>
-                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
-                                                        </connections>
-                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt"/>
                                                     <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
                                                         <connections>
                                                             <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
@@ -398,8 +384,8 @@
                                                 <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                        <menuItem title="Zoom" keyEquivalent="1" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" control="YES"/>
                                             <connections>
                                                 <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
                                             </connections>
@@ -466,17 +452,23 @@
                         <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <webView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QJA-JR-sDZ">
+                            <wkWebView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="01M-d5-cQ9">
                                 <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <webPreferences key="preferences" defaultFontSize="16" defaultFixedFontSize="13" minimumFontSize="0">
-                                    <nil key="identifier"/>
-                                </webPreferences>
-                            </webView>
+                                <wkWebViewConfiguration key="configuration">
+                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                    <wkPreferences key="preferences"/>
+                                </wkWebViewConfiguration>
+                            </wkWebView>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="01M-d5-cQ9" secondAttribute="trailing" id="JxA-uU-3VO"/>
+                            <constraint firstAttribute="bottom" secondItem="01M-d5-cQ9" secondAttribute="bottom" id="TlY-nU-mpC"/>
+                            <constraint firstItem="01M-d5-cQ9" firstAttribute="leading" secondItem="ERx-hH-rdd" secondAttribute="leading" id="XjL-P9-LOj"/>
+                            <constraint firstItem="01M-d5-cQ9" firstAttribute="top" secondItem="ERx-hH-rdd" secondAttribute="top" id="YrO-He-D0m"/>
+                        </constraints>
                     </view>
                     <connections>
-                        <outlet property="webview" destination="QJA-JR-sDZ" id="LNC-FP-nMe"/>
+                        <outlet property="webview" destination="01M-d5-cQ9" id="krK-7U-ykx"/>
                     </connections>
                 </viewController>
                 <customObject id="2Tp-Fl-jBw" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/Jupyter Notebook Viewer/ViewController.swift
+++ b/Jupyter Notebook Viewer/ViewController.swift
@@ -9,9 +9,9 @@
 import Cocoa
 import WebKit
 
-class ViewController: NSViewController {
-
-    @IBOutlet weak var webview: WebView!
+class ViewController: NSViewController, NSTextFinderBarContainer
+{
+    @IBOutlet weak var webview: WKWebView!
     
     weak var document: Document? {
         let window = self.view.window!
@@ -27,9 +27,52 @@ class ViewController: NSViewController {
         if (templateString != nil) {
             let jsonString = self.document!.jsonString
             let html = templateString!.replacingOccurrences(of: "%notebook-json%", with: jsonString)
-            webview.mainFrame!.loadHTMLString(html, baseURL: resourceURL)
+            webview.loadHTMLString(html, baseURL: resourceURL)
+        }
+        textFinder.client = webview
+        textFinder.findBarContainer = self
+    }
+    
+    // MARK: Text Search -
+    
+    var textFinder: NSTextFinder = NSTextFinder()
+    
+    @IBAction override func performTextFinderAction(_ sender: Any?) {
+        guard let action = NSTextFinder.Action(rawValue: (sender as! NSMenuItem).tag) else {
+            return
+        }
+        textFinder.performAction(action)
+    }
+    
+    // MARK: NSTextFinderBarContainer
+    
+    var findBarView: NSView? {
+        didSet {
+            if let findBarView = findBarView {
+                findBarView.frame = NSMakeRect(0, self.view.bounds.height - findBarView.frame.height, self.view.bounds.width, findBarView.frame.height)
+            }
         }
     }
-
+    
+    var isFindBarVisible: Bool = false {
+        didSet {
+            if isFindBarVisible, let findBarView = findBarView {
+                self.view.addSubview(findBarView)
+            } else {
+                findBarView?.removeFromSuperview()
+            }
+        }
+    }
+    
+    func findBarViewDidChangeHeight() {
+        if let findBarView = findBarView {
+            findBarView.frame = NSMakeRect(0, self.view.bounds.height - findBarView.frame.height, self.view.bounds.width, findBarView.frame.height)
+        }
+    }
+    
+    func contentView() -> NSView? {
+        view
+    }
+    
 }
 


### PR DESCRIPTION
This enables text search in notebooks.

To accomplish this:
* I converted the use of the deprecated `WebView` to the newer `WKWebView`.
* The standard "Find" menu items were changed to send the preferred `performTextFinderAction(_:)` action. 
* `ViewController` was extended to serve as a `NSTextFinderBarContainer` and mediate between an `NSTextFinder` and the `WKWebView`.

Note that bugs in WebKit seem to prevent incremental search from working properly. I left incremental search disabled to avoid various fragile-seeming workarounds that are discussed around the web.